### PR TITLE
Add on_hook option

### DIFF
--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -151,6 +151,11 @@ Sequence.prototype._setHooks = function() {
         _this._setNextCounter(_this._options.reference_fields, referenceValue, function(err, seq) {
             if (err) return done(err);
             doc[_this._options.inc_field] = seq;
+            
+            if (_this._options.on_hook && _.isFunction(_this._options.on_hook)) {
+                _this._options.on_hook.apply(doc);
+            }
+            
             done();
         }.bind(doc));
     });


### PR DESCRIPTION
Hi Ramiel,

Maybe it is good idea to have something like `on_hook` option in this plugin. `on_hook` is a callback that will be called when `hooks` is called. This feature will be useful to create something like a slug. Here's the example usage:

```
postSchema.plugin(AutoIncrement, {
	id: 'slug_seq',
	inc_field: 'slug_number',
	reference_fields: ['owner'],
	disable_hooks: false,
	on_hook: function () {
		var slug = someSlugGenerator(this.post_title);
		if (this.slug_number > 1)
			this.slug = slug + '-' + this.slug_number;
		else
			this.slug = slug;
	}
});
```

What do you think?