### PR TITLE
Fixed bug where the reference_fields were used as id

### DIFF
--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -100,7 +100,7 @@ Sequence.prototype._getCounterReferenceField = function(doc) {
     }else {
         for (var i in this._options.reference_fields) {
             reference.push({
-              [this._options.reference_fields[i]]: JSON.stringify(doc[this._options.reference_fields[i]])
+                [this._options.reference_fields[i]]: JSON.stringify(doc[this._options.reference_fields[i]])
             });
         }
     }

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -99,7 +99,9 @@ Sequence.prototype._getCounterReferenceField = function(doc) {
         reference = null;
     }else {
         for (var i in this._options.reference_fields) {
-            reference.push(JSON.stringify(doc[this._options.reference_fields[i]]));
+            reference.push({
+              [this._options.reference_fields[i]]: JSON.stringify(doc[this._options.reference_fields[i]])
+            });
         }
     }
 
@@ -161,7 +163,7 @@ Sequence.prototype._setHooks = function() {
         }
 
         referenceValue = _this._getCounterReferenceField(doc);
-        _this._setNextCounter(_this._options.reference_fields, referenceValue, function(err, seq) {
+        _this._setNextCounter(_this._options.id, referenceValue, function(err, seq) {
             if (err) return done(err);
             doc[_this._options.inc_field] = seq;
             done();

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -32,7 +32,7 @@ Sequence = function(schema, options) {
     if (_.isNull(options.reference_fields)) {
         options.reference_fields = options.inc_field;
         this._useReference = false;
-    }else {
+    } else {
         this._useReference = true;
     }
 
@@ -41,7 +41,7 @@ Sequence = function(schema, options) {
 
     if (this._useReference === true && _.isNull(options.id)) {
         throw new Error('Cannot use reference fields without specifying an id');
-    }else {
+    } else {
         options.id = options.id || options.inc_field;
     }
 
@@ -61,7 +61,7 @@ Sequence.getInstance = function(schema, options) {
     var sequence = new Sequence(schema, options),
         id = sequence.getId();
     
-    if(sequenceArchive.existsSequence(id)){
+    if (sequenceArchive.existsSequence(id)){
         throw new Error('Counter already defined for field "'+id+'"');
     }
     sequence.enable();
@@ -97,11 +97,11 @@ Sequence.prototype._getCounterReferenceField = function(doc) {
 
     if (this._useReference === false) {
         reference = null;
-    }else {
+    } else {
         for (var i in this._options.reference_fields) {
-            reference.push({
-                [this._options.reference_fields[i]]: JSON.stringify(doc[this._options.reference_fields[i]])
-            });
+            var obj = {};
+            obj[this._options.reference_fields[i]] = JSON.stringify(doc[this._options.reference_fields[i]]);
+            reference.push(obj);
         }
     }
 
@@ -114,7 +114,7 @@ Sequence.prototype._createSchemaKeys = function() {
         var fieldDesc = {};
         fieldDesc[this._options.inc_field] = 'Number';
         this._schema.add(fieldDesc);
-    }else {
+    } else {
         if (schemaKey.instance !== 'Number') {
             throw new Error('Auto increment field already present and not of type "Number"');
         }

--- a/test/base.js
+++ b/test/base.js
@@ -6,6 +6,9 @@ var chai = require('chai'),
     Schema = mongoose.Schema,
     AutoIncrement = require('../index');
 
+// Use native promises
+mongoose.Promise = global.Promise;
+
 describe('Basic => ', function() {
 
     before(function connection(done) {


### PR DESCRIPTION
Even though they are not supposed to be.
This caused different schemas to use the same counter, despite having different id's for the counters, but the same reference_fields.