### PR TITLE
support for sequential hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This plugin accepts a series of options.
 - **reference_fields**: The field to reference for a scoped counter. Optional
 - **disable_hooks**: If true, the counter will not be incremented on saving a new document. Default to `false`
 - **collection_name**: By default the collection name to mantain the status of the counters is `counters`. You can override it using this option
+- **parallel_hooks**: If true, hooks will be registered as parallel.  Default to `false`
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ This plugin accepts a series of options.
 - **reference_fields**: The field to reference for a scoped counter. Optional
 - **disable_hooks**: If true, the counter will not be incremented on saving a new document. Default to `false`
 - **collection_name**: By default the collection name to mantain the status of the counters is `counters`. You can override it using this option
-- **parallel_hooks**: If true, hooks will be registered as parallel.  Default to `false`
+- **parallel_hooks**: If true, hooks will be registered as parallel.  Default to `true`
 
 ## Notes
 

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -15,6 +15,7 @@ var _ = require('lodash'),
  * @param {string|string[]} [options.reference_fields=['_id']] Any field to consider as reference for the counter
  * @param {boolean} [options.disable_hooks] If true any hook will be disabled
  * @param {string} [options.collection_name='counters'] A name for the counter collection
+ * @param {boolean} [options.parallel_hooks] If true any hook will be registered as parallel
  * @throws {Error} If id is missing for counter which referes other fields
  * @throws {Error} If A counter collide with another because of same id
  */
@@ -24,7 +25,8 @@ Sequence = function(schema, options) {
     inc_field: '_id',
     reference_fields: null,
     disable_hooks: false,
-    collection_name: 'counters'
+    collection_name: 'counters',
+    parallel_hooks: true
   };
   options = options || {};
   _.defaults(options, defaults);
@@ -176,25 +178,42 @@ Sequence.prototype._createCounterModel = function() {
 };
 
 /**
+ * Return a pre-save hook for this sequence
+ *
+ * @method     _getPreSaveHook
+ */
+Sequence.prototype._getPreSaveHook = function() {
+  var sequence = this;
+  return function(next, done) {
+    var doc = this;
+    if (!sequence._options.parallel_hooks) {
+      done = next;
+    }
+    if (sequence._options.parallel_hooks) {
+      next();
+    }
+    if (!doc.isNew) {
+      return done();
+    }
+    sequence._setNextCounter(doc, function(err, seq) {
+      if (err) return done(err);
+      doc[sequence._options.inc_field] = seq;
+      done();
+    }.bind(doc));
+  };
+};
+
+/**
  * Set and handler for some hooks on the schema referenced by this sequence
  *
  * @method     _setHooks
  */
 Sequence.prototype._setHooks = function() {
-  this._schema.pre('save', true, (function(sequence){
-    return function(next, done) {
-      var doc = this;
-      next();
-      if (!doc.isNew) {
-        return done();
-      }
-      sequence._setNextCounter(doc, function(err, seq) {
-        if (err) return done(err);
-        doc[sequence._options.inc_field] = seq;
-        done();
-      }.bind(doc));
-    };
-  })(this));
+  if (this._options.parallel_hooks) {
+    this._schema.pre('save', true, this._getPreSaveHook());
+  } else {
+    this._schema.pre('save', this._getPreSaveHook());
+  }
 };
 
 /**

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -181,6 +181,7 @@ Sequence.prototype._createCounterModel = function() {
  * Return a pre-save hook for this sequence
  *
  * @method     _getPreSaveHook
+ * @return     {Mongoose-Hook} A mongoose hook
  */
 Sequence.prototype._getPreSaveHook = function() {
   var sequence = this;

--- a/test/base.js
+++ b/test/base.js
@@ -590,7 +590,7 @@ describe('Basic => ', function() {
       });
     });
 
-    describe('Error on hook', function(){
+    describe('Error on hook => ', function(){
       before(function(done) {
         var SimpleFieldSchema = new Schema({
           id: Number,
@@ -638,5 +638,43 @@ describe('Basic => ', function() {
       });
     });
 
+    describe('Parallel/Sequential hook behavior => ', function(){
+
+      describe('hook is registered as parallel => ', function(){
+
+        it('does not pass updated increment value to next hook', function(done){
+          var ParallelHooksSchema = new Schema({
+            parallel_id: Number,
+            val: String
+          });
+  
+          ParallelHooksSchema.plugin(AutoIncrement, {inc_field: 'parallel_id', parallel_hooks: true});
+          ParallelHooksSchema.pre('save', function(next) {
+            assert.isUndefined(this.parallel_id);
+            next();
+          });
+          var ParallelHooks = mongoose.model('ParallelHooks', ParallelHooksSchema);
+          ParallelHooks.create({val: 't1'}, done);
+        });
+      });
+
+      describe('hook is registered as sequential => ', function(){
+
+        it('passes updated increment value to next hook', function(done){
+          var SequentialHooksSchema = new Schema({
+            sequential_id: Number,
+            val: String
+          });
+  
+          SequentialHooksSchema.plugin(AutoIncrement, {inc_field: 'sequential_id', parallel_hooks: false});
+          SequentialHooksSchema.pre('save', function(next) {
+            assert.isDefined(this.sequential_id);
+            next();
+          });
+          var SequentialHooks = mongoose.model('SequentialHooks', SequentialHooksSchema);
+          SequentialHooks.create({val: 't1'}, done);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds a  `parallel_hooks` option. If it is set to `false`, hooks are registered as sequential. Option is `true` by default, to maintain current module behavior.

Closes #24
Closes #25 