### PR TITLE
Sequential hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ This plugin accepts a series of options.
 - **reference_fields**: The field to reference for a scoped counter. Optional
 - **disable_hooks**: If true, the counter will not be incremented on saving a new document. Default to `false`
 - **collection_name**: By default the collection name to mantain the status of the counters is `counters`. You can override it using this option
+- **parallel_hooks**: If true, hooks will be registered as parallel.  Default to `true`
 
 ## Notes
 

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -23,6 +23,7 @@ module.exports = function SequenceFactory(connection) {
    * for the counter
    * @param {boolean} [options.disable_hooks] If true any hook will be disabled
    * @param {string} [options.collection_name='counters'] A name for the counter collection
+   * @param {boolean} [options.parallel_hooks] If true any hook will be registered as parallel
    * @throws {Error} If id is missing for counter which referes other fields
    * @throws {Error} If A counter collide with another because of same id
    */
@@ -33,6 +34,7 @@ module.exports = function SequenceFactory(connection) {
       reference_fields: null,
       disable_hooks: false,
       collection_name: 'counters',
+      parallel_hooks: true,
     };
 
     const options = {
@@ -184,25 +186,48 @@ module.exports = function SequenceFactory(connection) {
   };
 
   /**
+   * Return a pre-save hook for this sequence
+   *
+   * @method     _getPreSaveHook
+   * @return     {Mongoose~Hook} A mongoose hook
+   */
+  Sequence.prototype._getPreSaveHook = function () {
+    const sequence = this;
+    return function (next, done) {
+      const doc = this;
+      let cb = done;
+      if (!sequence._options.parallel_hooks) {
+        cb = next;
+      }
+      if (sequence._options.parallel_hooks) {
+        next();
+      }
+      if (!doc.isNew) {
+        cb();
+        return;
+      }
+      sequence._setNextCounter(doc, (err, seq) => {
+        if (err) {
+          cb(err);
+          return;
+        }
+        doc[sequence._options.inc_field] = seq;
+        cb();
+      });
+    };
+  };
+
+  /**
    * Set and handler for some hooks on the schema referenced by this sequence
    *
    * @method     _setHooks
    */
   Sequence.prototype._setHooks = function () {
-    this._schema.pre('save', true, (function (sequence) {
-      return function (next, done) {
-        const doc = this;
-        next();
-        if (!doc.isNew) {
-          return done();
-        }
-        return sequence._setNextCounter(doc, ((err, seq) => {
-          if (err) return done(err);
-          doc[sequence._options.inc_field] = seq;
-          return done();
-        }));
-      };
-    }(this)));
+    if (this._options.parallel_hooks) {
+      this._schema.pre('save', true, this._getPreSaveHook());
+    } else {
+      this._schema.pre('save', this._getPreSaveHook());
+    }
   };
 
   /**

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -668,5 +668,41 @@ describe('Basic => ', () => {
         });
       });
     });
+
+    describe('Parallel/Sequential hook behavior => ', () => {
+      describe('hook is registered as parallel => ', () => {
+        it('does not pass updated increment value to next hook', (done) => {
+          const ParallelHooksSchema = new Schema({
+            parallel_id: Number,
+            val: String,
+          });
+
+          ParallelHooksSchema.plugin(AutoIncrement, { inc_field: 'parallel_id', parallel_hooks: true });
+          ParallelHooksSchema.pre('save', function (next) {
+            assert.isUndefined(this.parallel_id);
+            next();
+          });
+          const ParallelHooks = mongoose.model('ParallelHooks', ParallelHooksSchema);
+          ParallelHooks.create({ val: 't1' }, done);
+        });
+      });
+
+      describe('hook is registered as sequential => ', () => {
+        it('passes updated increment value to next hook', (done) => {
+          const SequentialHooksSchema = new Schema({
+            sequential_id: Number,
+            val: String,
+          });
+
+          SequentialHooksSchema.plugin(AutoIncrement, { inc_field: 'sequential_id', parallel_hooks: false });
+          SequentialHooksSchema.pre('save', function (next) {
+            assert.isDefined(this.sequential_id);
+            next();
+          });
+          const SequentialHooks = mongoose.model('SequentialHooks', SequentialHooksSchema);
+          SequentialHooks.create({ val: 't1' }, done);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds a  `parallel_hooks` option. If it is set to `false`, hooks are registered as sequential. Option is `true` by default, to maintain current module behavior.

Closes #24
Closes #25 