### PR TITLE
Allow nested field as inc_field

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ Model.counterReset('inhabitants_id',{country: 'France', city: 'Paris'}, function
 });
 ```
 
+### Nested fields
+
+It is possible to define a nested field as counter, using `.` as path separator:
+
+```js
+NestedSchema = new mongoose.Schema({
+    name: { type: String },
+    registration: {
+        date: { type: Date },
+        number: { type: Number }
+    }
+});
+
+NestedSchema.plugin(AutoIncrement, { id: 'user_registration_seq', inc_field: 'registration.number' });
+```
+
+
 ### Options
 
 This plugin accepts a series of options.

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -218,7 +218,7 @@ module.exports = function SequenceFactory(connection) {
           return;
         }
         if (!_.isNull(createSeq)) {
-          _.set(doc, sequence._options.inc_field.split('.'), createSeq);
+          doc.set(sequence._options.inc_field, createSeq);
           cb();
         } else {
           sequence._setNextCounter(doc, (setError, setSeq) => {
@@ -226,7 +226,7 @@ module.exports = function SequenceFactory(connection) {
               cb(setError);
               return;
             }
-            _.set(doc, sequence._options.inc_field.split('.'), setSeq);
+            doc.set(sequence._options.inc_field, setSeq);
             cb();
           });
         }
@@ -275,7 +275,7 @@ module.exports = function SequenceFactory(connection) {
           return;
         }
         if (!_.isNull(createSeq)) {
-          _.set(this, sequence._options.inc_field.split('.'), createSeq);
+          this.set(sequence._options.inc_field, createSeq);
           this.save(callback);
         } else {
           sequence._setNextCounter(this, (setError, setSeq) => {
@@ -283,7 +283,7 @@ module.exports = function SequenceFactory(connection) {
               callback(setError);
               return;
             }
-            _.set(this, sequence._options.inc_field.split('.'), setSeq);
+            this.set(sequence._options.inc_field, setSeq);
             this.save(callback);
           });
         }

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -275,7 +275,7 @@ module.exports = function SequenceFactory(connection) {
           return;
         }
         if (!_.isNull(createSeq)) {
-          this[sequence._options.inc_field] = createSeq;
+          _.set(this, sequence._options.inc_field.split('.'), createSeq);
           this.save(callback);
         } else {
           sequence._setNextCounter(this, (setError, setSeq) => {
@@ -283,7 +283,7 @@ module.exports = function SequenceFactory(connection) {
               callback(setError);
               return;
             }
-            this[sequence._options.inc_field] = setSeq;
+            _.set(this, sequence._options.inc_field.split('.'), setSeq);
             this.save(callback);
           });
         }

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -8,7 +8,9 @@ let Sequence;
 
 module.exports = function SequenceFactory(connection) {
   if (arguments.length !== 1) {
-    throw new Error('Please, pass mongoose while requiring mongoose-sequence: https://github.com/ramiel/mongoose-sequence#requiring');
+    throw new Error(
+      'Please, pass mongoose while requiring mongoose-sequence: https://github.com/ramiel/mongoose-sequence#requiring',
+    );
   }
 
   /**
@@ -216,7 +218,7 @@ module.exports = function SequenceFactory(connection) {
           return;
         }
         if (!_.isNull(createSeq)) {
-          doc[sequence._options.inc_field] = createSeq;
+          _.set(doc, sequence._options.inc_field.split('.'), createSeq);
           cb();
         } else {
           sequence._setNextCounter(doc, (setError, setSeq) => {
@@ -224,7 +226,7 @@ module.exports = function SequenceFactory(connection) {
               cb(setError);
               return;
             }
-            doc[sequence._options.inc_field] = setSeq;
+            _.set(doc, sequence._options.inc_field.split('.'), setSeq);
             cb();
           });
         }
@@ -335,13 +337,13 @@ module.exports = function SequenceFactory(connection) {
   };
 
   /**
- * Utility function to create a record in counter before incrementing
- *
- * @method     _createCounter
- * @param      {object}    doc       A mongoose model which need to receive the
- *                                   increment
- * @param      {Function}  callback  Called with the sequence counter
- */
+   * Utility function to create a record in counter before incrementing
+   *
+   * @method     _createCounter
+   * @param      {object}    doc       A mongoose model which need to receive the
+   *                                   increment
+   * @param      {Function}  callback  Called with the sequence counter
+   */
   Sequence.prototype._createCounter = function (doc, callback) {
     const id = this.getId();
     const referenceValue = this._getCounterReferenceField(doc);

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -750,5 +750,46 @@ describe('Basic => ', () => {
         });
       });
     });
+
+    describe('Increment nested fields', () => {
+      let NestedField;
+
+      beforeAll(() => {
+        const NestedFieldSchema = new Schema({
+          parent: { nested: { type: Number } },
+        });
+        NestedFieldSchema.plugin(AutoIncrement, { inc_field: 'parent.nested' });
+        NestedField = mongoose.model('NestedField', NestedFieldSchema);
+      });
+
+      it('populates the nested fields with incremented values', (done) => {
+        let count = 0;
+        const documents = [];
+
+        async.whilst(
+          () => count < 5,
+
+          (callback) => {
+            count += 1;
+            const t = new NestedField();
+            documents.push(t);
+            t.save(callback);
+          },
+
+          (err) => {
+            if (err) return done(err);
+            const nestedValues = documents.map(d => d.parent.nested);
+
+            try {
+              assert.sameDeepMembers(nestedValues, [1, 2, 3, 4, 5]);
+            } catch (e) {
+              return done(e);
+            }
+
+            return done();
+          },
+        );
+      });
+    });
   });
 });

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -420,7 +420,7 @@ describe('Basic => ', () => {
         });
       });
 
-      describe('Two schema with the samere references', () => {
+      describe('Two schema with the same references', () => {
         let RefFirst;
         let RefSecond;
 
@@ -751,8 +751,8 @@ describe('Basic => ', () => {
       });
     });
 
-    describe('Increment nested fields', () => {
-      describe('Automatic increment on creation', () => {
+    describe('Increment nested fields =>', () => {
+      describe('Automatic increment on creation =>', () => {
         let NestedField;
 
         beforeAll(() => {
@@ -793,7 +793,7 @@ describe('Basic => ', () => {
         });
       });
 
-      describe('Manual increment', () => {
+      describe('Manual increment =>', () => {
         let NestedManual;
         beforeAll(() => {
           const NestedManualFieldSchema = new Schema({

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -752,43 +752,85 @@ describe('Basic => ', () => {
     });
 
     describe('Increment nested fields', () => {
-      let NestedField;
+      describe('Automatic increment on creation', () => {
+        let NestedField;
 
-      beforeAll(() => {
-        const NestedFieldSchema = new Schema({
-          parent: { nested: { type: Number } },
+        beforeAll(() => {
+          const NestedFieldSchema = new Schema({
+            parent: { nested: { type: Number } },
+          });
+          NestedFieldSchema.plugin(AutoIncrement, { inc_field: 'parent.nested' });
+          NestedField = mongoose.model('NestedField', NestedFieldSchema);
         });
-        NestedFieldSchema.plugin(AutoIncrement, { inc_field: 'parent.nested' });
-        NestedField = mongoose.model('NestedField', NestedFieldSchema);
+
+        it('populates the nested fields with incremented values', (done) => {
+          let count = 0;
+          const documents = [];
+
+          async.whilst(
+            () => count < 5,
+
+            (callback) => {
+              count += 1;
+              const t = new NestedField();
+              documents.push(t);
+              t.save(callback);
+            },
+
+            (err) => {
+              if (err) return done(err);
+              const nestedValues = documents.map(d => d.parent.nested);
+
+              try {
+                assert.sameDeepMembers(nestedValues, [1, 2, 3, 4, 5]);
+              } catch (e) {
+                return done(e);
+              }
+
+              return done();
+            },
+          );
+        });
       });
 
-      it('populates the nested fields with incremented values', (done) => {
-        let count = 0;
-        const documents = [];
+      describe('Manual increment', () => {
+        let NestedManual;
+        beforeAll(() => {
+          const NestedManualFieldSchema = new Schema({
+            name: { type: String },
+            parent: { nested: { type: Number } },
+          });
+          NestedManualFieldSchema.plugin(AutoIncrement, {
+            id: 'nested_manual_seq',
+            inc_field: 'parent.nested',
+            disable_hooks: true,
+          });
+          NestedManual = mongoose.model('NestedManualField', NestedManualFieldSchema);
+          NestedManual.create([{ name: 't1' }, { name: 't2' }]);
+        });
 
-        async.whilst(
-          () => count < 5,
-
-          (callback) => {
-            count += 1;
-            const t = new NestedField();
-            documents.push(t);
-            t.save(callback);
-          },
-
-          (err) => {
+        it('is not incremented on save', (done) => {
+          const t = new NestedManual({});
+          t.save((err) => {
             if (err) return done(err);
-            const nestedValues = documents.map(d => d.parent.nested);
-
-            try {
-              assert.sameDeepMembers(nestedValues, [1, 2, 3, 4, 5]);
-            } catch (e) {
-              return done(e);
-            }
-
+            assert.notEqual(t.parent.nested, 1);
             return done();
-          },
-        );
+          });
+        });
+
+        it('is incremented manually', (done) => {
+          NestedManual.findOne({ name: 't1' }, (err, entity) => {
+            if (err) {
+              done(err);
+              return;
+            }
+            entity.setNext('nested_manual_seq', (e, entityInstance) => {
+              if (e) return done(e);
+              assert.deepEqual(entityInstance.parent.nested, 1);
+              return done();
+            });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
(WIP: opened early to allow feedback/comments)

This PR allows the use of a nested field as `inc_field`, as discussed on #75.

Uses schema path notation with `.` as separator (e.g. `parentField.childFieldToInc`).

Closes #75 