### PR TITLE
Add NPM badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/ramiel/mongoose-sequence.svg?branch=master)](https://travis-ci.org/ramiel/mongoose-sequence)
 [![Coverage Status](https://coveralls.io/repos/github/ramiel/mongoose-sequence/badge.svg?branch=master)](https://coveralls.io/github/ramiel/mongoose-sequence?branch=master)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/FabrizioRuggeri)
+![npm](https://img.shields.io/npm/v/mongoose-sequence)
 
 This plugin lets you create fields which autoincrement their value:  
 - every time a new document is inserted in a collection  


### PR DESCRIPTION
I'm linking to the plugin's GitHub from SO and other places, since it shows more recent activity than NPM, but we should link to NPM as well.