### PR TITLE
Passing mongoose module instead of passing mongoose connection

### DIFF
--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const async = require('async');
-const mongoose = require('mongoose');
 const SequenceArchive = require('./sequence_archive');
 
 const sequenceArchive = SequenceArchive.getSingleton();
@@ -9,11 +8,11 @@ let Sequence;
 const resolve = (path, obj) =>
   path.split('.').reduce((prev, curr) => (prev ? prev[curr] : null), obj);
 
-module.exports = function SequenceFactory(connection) {
-  if (arguments.length !== 1) {
-    throw new Error(
-      'Please, pass mongoose while requiring mongoose-sequence: https://github.com/ramiel/mongoose-sequence#requiring',
-    );
+module.exports = function SequenceFactory(mongoose) {
+  const connection = mongoose.connection;
+
+  if (!connection || !connection.modelNames) {
+    throw new Error('Please pass the mongoose module as argument');
   }
 
   /**


### PR DESCRIPTION
Previously, the code expected a 'mongoose connection' while internally using the mongoose module to create the schema. This caused issues with other plugins. This commit addresses the issue #138 by refactoring the code to pass the mongoose module instead of the mongoose connection. By doing so, it ensures compatibility with other plugins.
Fixes isseu #138 