### PR TITLE
Upgrade to Mongoose 9

### DIFF
--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -30,7 +30,6 @@ module.exports = function SequenceFactory(connection) {
    * @param {string} [options.collection_name='counters'] A name for the counter collection
    * @param {boolean} [options.exclusive=true] Set False to allow sharing same Sequence with
    *                                           multiple Schemas.
-   * @param {boolean} [options.parallel_hooks] If true any hook will be registered as parallel
    * @param {Number} [options.start_seq=1] The number to start the sequence on
    * @param {Number} [options.inc_amount=1] The number to increment by
    * @throws {Error} If id is missing for counter which referes other fields
@@ -45,7 +44,6 @@ module.exports = function SequenceFactory(connection) {
       reference_fields: null,
       disable_hooks: false,
       collection_name: 'counters',
-      parallel_hooks: true,
       exclusive: true,
     };
 
@@ -218,37 +216,31 @@ module.exports = function SequenceFactory(connection) {
    */
   Sequence.prototype._getPreSaveHook = function () {
     const sequence = this;
-    return function (next, done) {
+    return function () {
       const doc = this;
-      let cb = done;
-      if (!sequence._options.parallel_hooks) {
-        cb = next;
-      }
-      if (sequence._options.parallel_hooks) {
-        next();
-      }
       if (!doc.isNew) {
-        cb();
         return;
       }
-      sequence._createCounter(doc, (createErr, createSeq) => {
-        if (createErr) {
-          cb(createErr);
-          return;
-        }
-        if (!_.isNull(createSeq)) {
-          doc.set(sequence._options.inc_field, createSeq);
-          cb();
-        } else {
-          sequence._setNextCounter(doc, (setError, setSeq) => {
-            if (setError) {
-              cb(setError);
-              return;
-            }
-            doc.set(sequence._options.inc_field, setSeq);
-            cb();
-          });
-        }
+      return new Promise((resolve, reject) => {
+        sequence._createCounter(doc, (createErr, createSeq) => {
+          if (createErr) {
+            reject(createErr);
+            return;
+          }
+          if (!_.isNull(createSeq)) {
+            doc.set(sequence._options.inc_field, createSeq);
+            resolve();
+          } else {
+            sequence._setNextCounter(doc, (setError, setSeq) => {
+              if (setError) {
+                reject(setError);
+                return;
+              }
+              doc.set(sequence._options.inc_field, setSeq);
+              resolve();
+            });
+          }
+        });
       });
     };
   };
@@ -259,11 +251,7 @@ module.exports = function SequenceFactory(connection) {
    * @method     _setHooks
    */
   Sequence.prototype._setHooks = function () {
-    if (this._options.parallel_hooks) {
-      this._schema.pre('save', true, this._getPreSaveHook());
-    } else {
-      this._schema.pre('save', this._getPreSaveHook());
-    }
+    this._schema.pre('save', this._getPreSaveHook());
   };
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-plugin-jest": "^27.6.0",
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
-        "mongoose": "8.0.3",
+        "mongoose": "9.1.0",
         "prettier": "^3.1.1",
         "sinon": "17.0.1"
       },
@@ -1225,10 +1225,11 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
-      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.4.tgz",
+      "integrity": "sha512-p7X/ytJDIdwUfFL/CLOhKgdfJe1Fa8uw9seJYvdOmnP9JBWGWHW69HkOixXS6Wy9yvGf1MbhcS6lVmrhy4jm2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -1440,15 +1441,16 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -1983,12 +1985,13 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
-      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.0.0.tgz",
+      "integrity": "sha512-Kwc6Wh4lQ5OmkqqKhYGKIuELXl+EPYSCObVE6bWsp1T/cGkOCBN0I8wF/T44BiuhHyNi1mmKVPXk60d41xZ7kw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/buffer-from": {
@@ -4266,12 +4269,13 @@
       "dev": true
     },
     "node_modules/kareem": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
-      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.0.0.tgz",
+      "integrity": "sha512-RKhaOBSPN8L7y4yAgNhDT2602G5FD6QbOIISbjN9D6mjHPeqeg7K+EB5IGSU5o81/X2Gzm3ICnAvQW3x3OP8HA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/kleur": {
@@ -4407,7 +4411,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4489,26 +4494,27 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
-      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
+      "integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.2.0",
-        "mongodb-connection-string-url": "^2.6.0"
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.0.0",
+        "mongodb-connection-string-url": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -4535,31 +4541,35 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.0.tgz",
+      "integrity": "sha512-irhhjRVLE20hbkRl4zpAYLnDMM+zIZnp0IDB9akAFFUZp/3XdOfwwddc7y6cNvF2WCEtfTYRwYbIfYa2kVY0og==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.0.3.tgz",
-      "integrity": "sha512-LJRT0yP4TW14HT4r2RkxqyvoTylMSzWpl5QOeVHTnRggCLQSpkoBdgbUtORFq/mSL2o9cLCPJz+6uzFj25qbHw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.1.0.tgz",
+      "integrity": "sha512-RVCApwqD6q+O3rsnypmiL1K5+mkN5DwA7BO5a5ofCKh/EZB9FKvcQ4EiqHNmRye3cXhz5DmQ/aVyfBFkXnUbrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bson": "^6.2.0",
-        "kareem": "2.5.1",
-        "mongodb": "6.2.0",
+        "kareem": "3.0.0",
+        "mongodb": "~7.0",
         "mpath": "0.9.0",
-        "mquery": "5.0.0",
+        "mquery": "6.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4582,15 +4592,13 @@
       }
     },
     "node_modules/mquery": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
-      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+      "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
       "dev": true,
-      "dependencies": {
-        "debug": "4.x"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/ms": {
@@ -5036,10 +5044,11 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5336,10 +5345,11 @@
       }
     },
     "node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
-      "dev": true
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -5413,6 +5423,7 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -5651,15 +5662,16 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -5860,21 +5872,23 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
-    "mongoose": "8.0.3",
+    "mongoose": "9.1.0",
     "prettier": "^3.1.1",
     "sinon": "17.0.1"
   },

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -941,63 +941,27 @@ describe('Basic =>', () => {
       });
     });
 
-    describe('Parallel/Sequential hook behavior =>', () => {
-      describe('hook is registered as parallel =>', () => {
-        it('does not pass updated increment value to next hook', (done) => {
-          const ParallelHooksSchema = new Schema({
-            parallel_id: Number,
-            val: String,
-          });
-
-          ParallelHooksSchema.plugin(AutoIncrement, {
-            inc_field: 'parallel_id',
-            parallel_hooks: true,
-          });
-          ParallelHooksSchema.pre('save', function (next) {
-            assert.isUndefined(this.parallel_id);
-            next();
-          });
-          const ParallelHooks = mongoose.model(
-            'ParallelHooks',
-            ParallelHooksSchema,
-          );
-          ParallelHooks.create({ val: 't1' })
-            .then((result) => {
-              done(null, result);
-            })
-            .catch((err) => {
-              done(err);
-            });
+    describe('Hook behavior =>', () => {
+      it('passes updated increment value to next hook', (done) => {
+        const HooksSchema = new Schema({
+          sequential_id: Number,
+          val: String,
         });
-      });
 
-      describe('hook is registered as sequential =>', () => {
-        it('passes updated increment value to next hook', (done) => {
-          const SequentialHooksSchema = new Schema({
-            sequential_id: Number,
-            val: String,
-          });
-
-          SequentialHooksSchema.plugin(AutoIncrement, {
-            inc_field: 'sequential_id',
-            parallel_hooks: false,
-          });
-          SequentialHooksSchema.pre('save', function (next) {
-            assert.isDefined(this.sequential_id);
-            next();
-          });
-          const SequentialHooks = mongoose.model(
-            'SequentialHooks',
-            SequentialHooksSchema,
-          );
-          SequentialHooks.create({ val: 't1' })
-            .then((result) => {
-              done(null, result);
-            })
-            .catch((err) => {
-              done(err);
-            });
+        HooksSchema.plugin(AutoIncrement, {
+          inc_field: 'sequential_id',
         });
+        HooksSchema.pre('save', function () {
+          assert.isDefined(this.sequential_id);
+        });
+        const HooksModel = mongoose.model('HooksModel', HooksSchema);
+        HooksModel.create({ val: 't1' })
+          .then((result) => {
+            done(null, result);
+          })
+          .catch((err) => {
+            done(err);
+          });
       });
     });
 


### PR DESCRIPTION
Mongoose 9 removed `next()` in pre middlewares (see [Mongoose.js: Migrating from 8.x to 9.x](https://mongoosejs.com/docs/migrating_to_9.html#pre-middleware-no-longer-supports-next), which are used by mongoose-sequence. My pull request fixes this by refactoring the pre-save hooks to return a promise instead of using callbacks. Moreover, the _parallel_hooks_ option was removed, which is not supported in the latest Mongoose versions. The test functions related to the sequential and parallel hooks were also updated accordingly.